### PR TITLE
Add xhr object to FETCH event trigger in fetchReplacement function

### DIFF
--- a/lib/assets/javascripts/turbolinks.coffee
+++ b/lib/assets/javascripts/turbolinks.coffee
@@ -70,11 +70,12 @@ fetchReplacement = (url, options) ->
   options.cacheRequest ?= requestCachingEnabled
   options.showProgressBar ?= true
 
-  triggerEvent EVENTS.FETCH, url: url.absolute
-
   xhr?.abort()
   xhr = new XMLHttpRequest
   xhr.open 'GET', url.formatForXHR(cache: options.cacheRequest), true
+
+  triggerEvent EVENTS.FETCH, url: url.absolute, xhr: xhr
+
   xhr.setRequestHeader 'Accept', 'text/html, application/xhtml+xml, application/xml'
   xhr.setRequestHeader 'X-XHR-Referer', referer
 


### PR DESCRIPTION
Task Link(s):
https://app.asana.com/1/1110661684743291/project/1210329604201628/task/1209839761729482?focus=true

Purpose:
As a developer, I want to fork "Turbolinks Classic" gem and patch the `fetchReplacement` function in , So that I can inject custom headers via an event listener

Changes:
- [Add xhr object to FETCH event trigger in fetchReplacement function](https://github.com/turbolinks/turbolinks-classic/commit/6680622ec80ece8d206f29e5fd9fecf611084f90)